### PR TITLE
gemini: Fix front camera mount angle

### DIFF
--- a/gemini/proprietary/etc/camera/msm8996_camera.xml
+++ b/gemini/proprietary/etc/camera/msm8996_camera.xml
@@ -143,7 +143,7 @@ LensInfo : Information of the lens present in the module.
     <ChromatixName>ov4688_chromatix</ChromatixName>
     <ModesSupported>1</ModesSupported>
     <Position>FRONT</Position>
-    <MountAngle>360</MountAngle>
+    <MountAngle>270</MountAngle>
     <CSIInfo>
       <CSIDCore>2</CSIDCore>
       <LaneMask>0x1F</LaneMask>
@@ -166,7 +166,7 @@ LensInfo : Information of the lens present in the module.
     <ChromatixName>ov4688_primax_chromatix</ChromatixName>
     <ModesSupported>1</ModesSupported>
     <Position>FRONT</Position>
-    <MountAngle>360</MountAngle>
+    <MountAngle>270</MountAngle>
     <CSIInfo>
       <CSIDCore>2</CSIDCore>
       <LaneMask>0x1F</LaneMask>


### PR DESCRIPTION
 * The correct mount angle for front camera is 270, as seen
   on stock camera configs from natrium or capricorn.
   Fixes the reversed front camera render when HAL3 is enabled.

Change-Id: Ic135469c2c506156e599cd16d124c34918b2281d